### PR TITLE
replicationcontroller jenkins-builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ jenkins-leader-to8xg    1/1       Running   0          4h
 Resize the build agent replication controller to contain 5 pods:
 
 ```shell
-$ kubectl scale rc/jenkins-builder --replicas=5
+$ kubectl scale replicationcontroller jenkins-builder --replicas=5
 ```
 
 Use `kubectl` to verify that 5 pods are running.


### PR DESCRIPTION
Curiously "rc/jenkins-builder" works as the parameter but is this syntactically correct?

"rc jenkins-builder" may be clearer but perhaps most clear is "replicationcontroller jenkins-builder"
